### PR TITLE
Changes in evaluate.py and README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,9 @@ This system reads the CSV of video games ratings and calculates the average rati
 
 This script trains a traditional machine learning recommendation model for video games using metadata such as genre, platform, and critic/user scores. It leverages scikit-learn pipelines and preprocessing steps to encode categorical features, handle missing values, and scale numerical inputs. The model is trained using a RandomForestRegressor to predict user preferences based on aggregated features. Evaluation metrics such as MSE, RMSE, and R² are calculated to assess model performance. The final trained model is saved as a .pkl file and used by the backend to provide fast, lightweight recommendations in the GameQuest app.
 
-
-
 ### Deep Learning Model
 
 The model uses a Neural Collaborative Filtering (NCF) architecture with separate GMF and MLP embedding layers. GMF computes the element-wise product of user and item embeddings to capture linear interactions. MLP concatenates the same embeddings and passes them through two fully connected layers with ReLU and dropout to model non-linear interactions. Outputs from both paths are concatenated and passed through a final linear layer to predict ratings. The model is trained using MSE loss and the Adam optimizer. Training uses a custom PyTorch Dataset and DataLoader, with 20% of the user-game interaction data used for training. The model runs for 50 epochs and saves weights after training for inference. The reason we are using 20% of the user-game interaction data for training is because the dataset is extremely big and our machines kept crashing (20% of the data still contains +100,000 data points). The model is trained to predict ratings for video games and thus we have chosen to use MSE as the main metric for training.
-
-The model uses a Neural Collaborative Filtering (NCF) architecture with separate GMF and MLP embedding layers. GMF computes the element-wise product of user and item embeddings to capture linear interactions. MLP concatenates the same embeddings and passes them through two fully connected layers with ReLU and dropout to model non-linear interactions. Outputs from both paths are concatenated and passed through a final linear layer to predict ratings. The model is trained using MSE loss and the Adam optimizer. Training uses a custom PyTorch Dataset and DataLoader, with 20% of the user-game interaction data used for training. The model runs for 50 epochs and saves weights after training for inference. The reason we are using 20% of the user-game interaction data for training is because the dataset is extremely big and our machines kept crashing (20% of the data still contains +100,000 data points). The model is trained to predict ratings for video games and thus we have chosen to use MSE as the main metric for training.
-
 
 ## Data Processing pipeline 
 

--- a/README.md
+++ b/README.md
@@ -134,20 +134,12 @@ This dataset is used in our project to supply items information.
 This dataset is used in our project to supply users information such as the user's rating of the different games (we are using the Rating Given By The Reviewer and normalizing it between 0 and 10 as the rating and the Reviewer Name as the user_id). 
 
 ## Review of Relevant Previous Efforts on this Dataset
+
 When it comes to previous efforts done on the datasets, only a few notebooks have been pushed to the Kaggle dataset repo. All of these notebooks are performing EDA on the datasets, but none of them have gone to the extent of creating models to recommend items. One of the notebooks implements an ML model, but that is used to predict game features rather than recommending games. 
 
 ## Model evaluation process & Metric Selection 
 
-
 To evaluate the effectiveness of the recommendation models, we employed a hybrid evaluation strategy focusing on both regression accuracy and ranking quality. The dataset is first split into a training and testing set, ensuring that only users seen during training are included in the test set to reflect a realistic inference scenario. Since the model is trained to predict the explicit user rating for a game (e.g., 8.5 out of 10), we first use Mean Squared Error (MSE) and Root Mean Squared Error (RMSE) to quantify how close the predicted ratings are to the actual user ratings. We also include the R² Score, which captures how much variance in user ratings the model can explain, offering a more interpretable metric for overall model fit. However, since the ultimate goal of the system is to recommend the most relevant games to users, we also evaluate how well the model ranks items using Mean Average Precision at K (MAP@10) and Normalized Discounted Cumulative Gain at K (NDCG@10). These ranking metrics assess how many of the top-K recommended games are actually relevant (MAP) and how highly ranked the relevant games are (NDCG), placing greater emphasis on correct recommendations near the top of the list. This hybrid evaluation setup ensures the model not only predicts ratings accurately but also delivers high-quality, position-aware recommendations in real-world usage
-
-
-
-The model is evaluated using offline metrics on a held-out test set that contains user-game interactions not seen during training. For each user, the model generates a ranked list of top-K recommended games, excluding items the user has already interacted with. The predicted list is compared against the actual set of games rated by the user in the test set. The evaluation script computes four ranking-based metrics: Precision@K, Recall@K, Mean Average Precision (MAP@K), and Normalized Discounted Cumulative Gain (NDCG@K). These metrics were chosen to assess the model's ability to rank relevant items at the top of the recommendation list. Precision@K captures how many of the top-K items are actually relevant, Recall@K measures coverage of the relevant items, MAP@K rewards both relevance and ordering, and NDCG@K emphasizes the importance of placing relevant items earlier in the list. Together, they provide a comprehensive view of recommendation quality beyond simple rating prediction
-
-To evaluate the effectiveness of the recommendation models, we employed a hybrid evaluation strategy focusing on both regression accuracy and ranking quality. The dataset is first split into a training and testing set, ensuring that only users seen during training are included in the test set to reflect a realistic inference scenario. Since the model is trained to predict the explicit user rating for a game (e.g., 8.5 out of 10), we first use Mean Squared Error (MSE) and Root Mean Squared Error (RMSE) to quantify how close the predicted ratings are to the actual user ratings. We also include the R² Score, which captures how much variance in user ratings the model can explain, offering a more interpretable metric for overall model fit. However, since the ultimate goal of the system is to recommend the most relevant games to users, we also evaluate how well the model ranks items using Mean Average Precision at K (MAP@10) and Normalized Discounted Cumulative Gain at K (NDCG@10). These ranking metrics assess how many of the top-K recommended games are actually relevant (MAP) and how highly ranked the relevant games are (NDCG), placing greater emphasis on correct recommendations near the top of the list. This hybrid evaluation setup ensures the model not only predicts ratings accurately but also delivers high-quality, position-aware recommendations in real-world usage
-
-
 
 ## Modeling Approach 
 
@@ -159,8 +151,6 @@ This system reads the CSV of video games ratings and calculates the average rati
 
 
 ### Deep Learning Model
-
-
 
 The model uses a Neural Collaborative Filtering (NCF) architecture with separate GMF and MLP embedding layers. GMF computes the element-wise product of user and item embeddings to capture linear interactions. MLP concatenates the same embeddings and passes them through two fully connected layers with ReLU and dropout to model non-linear interactions. Outputs from both paths are concatenated and passed through a final linear layer to predict ratings. The model is trained using MSE loss and the Adam optimizer. Training uses a custom PyTorch Dataset and DataLoader, with 20% of the user-game interaction data used for training. The model runs for 50 epochs and saves weights after training for inference. The reason we are using 20% of the user-game interaction data for training is because the dataset is extremely big and our machines kept crashing (20% of the data still contains +100,000 data points). The model is trained to predict ratings for video games and thus we have chosen to use MSE as the main metric for training.
 
@@ -175,20 +165,35 @@ The preprocessing pipeline first cleans the video game dataset by handling missi
 ## Models evaluated and Model Selected 
 **Naive Approach results**
 
-- MSE: 8.4607
-- RMSE: 2.9087
-- R^2: -0.3020
-- MAP@10: 0.0007
-- NDCG@10: 0.0017
+On the train dataset:
+- MSE: 5.9508
+- RMSE: 2.4394
+- R^2: 0.2445
+- MAP@10: 0.0004
+- NDCG@10: 0.0011
+
+On the test dataset:
+- MSE: 8.8834
+- RMSE: 2.9805
+- R^2: 0.2465
+- MAP@10: 0.0002
+- NDCG@10: 0.0016
 
 **Traditional Approach results**
 
 
 
 **DL Apporach results**
+
 We explored multiple deep learning approaches to recommendation, evaluating how different training objectives affect both rating accuracy and recommendation quality. The first model followed the standard Neural Collaborative Filtering (NCF) architecture trained with Mean Squared Error (MSE) loss to predict explicit user ratings. This model achieved excellent regression performance (MSE: 0.0177, RMSE: 0.1330, R²: 0.9978), but its ability to rank relevant games was limited (MAP@10: 0.0199, NDCG@10: 0.0457), revealing a disconnect between accurate rating prediction and practical recommendation quality. To address this, we trained a second version of the model using Bayesian Personalized Ranking (BPR) loss, optimizing directly for pairwise ranking. This model dramatically improved ranking metrics (MAP@10: 0.9253, NDCG@10: 0.9435) but lost accuracy in rating prediction (RMSE: 8.04), making it unsuitable for regression-based scoring. Observing the complementary strengths of both models, we introduced a hybrid training objective combining the two loss functions: α * MSE + (1 - α) * BPR. This combined approach delivered strong performance across the board, balancing rating accuracy (MSE: 0.2047, RMSE: 0.4525, R²: 0.9740) with robust ranking metrics (MAP@10: 0.8955, NDCG@10: 0.9236). A hybrid approach with both content-based and collaborative filtering might be better for our use case. However, due to time constraints, we decided to go with the model combining both losses for our deep learning approach.
 
-Compare traditional and DL to the naive approach
+On the test dataset:
+- Regression Metrics → MSE: 0.2047 | RMSE: 0.4525 | R²: 0.9740
+- Ranking Metrics → MAP@10: 0.8961 | NDCG@10: 0.9241
+
+On the test dataset:
+- Regression Metrics → MSE: 22.4380 | RMSE: 4.7369 | R²: -0.9044
+- Ranking Metrics → MAP@10: 0.5701 | NDCG@10: 0.7211
 
 ## Demo of Deployed App 
 [Insert link to the deployed app]

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -5,6 +5,119 @@ from torch.utils.data import DataLoader
 from sklearn.metrics import mean_squared_error, r2_score
 from collections import defaultdict
 import random
+import json
+
+from torch.utils.data import DataLoader
+
+from deep_learning_training import RecommendationDataset, NCFRecommendationSystem
+import pandas as pd
+
+torch.manual_seed(42)
+
+device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
+print(f'Using device: {device}')
+
+class NaiveGameRecommender:
+    def __init__(self, user_data_path):
+        self.user_data = pd.read_csv(user_data_path)
+        self.avg_ratings = None
+        self.compute_average_ratings()
+
+    def compute_average_ratings(self):
+        self.avg_ratings = self.user_data.groupby("game_title")["rating"].mean().reset_index()
+
+    def get_recommendations(self, target_game, top_n=5):
+        recs = self.avg_ratings[self.avg_ratings["game_title"] != target_game]
+        recs = recs.sort_values(by="rating", ascending=False)
+        return recs["game_title"].head(top_n).tolist()
+
+    def mean_average_precision_at_k(self, actual, predicted, k):
+        avg_precisions = []
+        for a, p in zip(actual, predicted):
+            if not a:
+                continue
+            hits = 0
+            sum_precisions = 0.0
+            for i, pred in enumerate(p[:k]):
+                if pred in a:
+                    hits += 1
+                    sum_precisions += hits / (i + 1.0)
+            avg_precisions.append(sum_precisions / min(len(a), k))
+        return np.mean(avg_precisions)
+
+    def ndcg_at_k(self, actual, predicted, k):
+        def dcg(rel):
+            return sum([(2**r - 1) / np.log2(idx + 2) for idx, r in enumerate(rel)])
+        ndcgs = []
+        for a, p in zip(actual, predicted):
+            relevance = [1 if item in a else 0 for item in p[:k]]
+            ideal_relevance = sorted(relevance, reverse=True)
+            ndcgs.append(dcg(relevance) / (dcg(ideal_relevance) or 1))
+        return np.mean(ndcgs)
+
+    def evaluate_metrics(self, test_ratio=0.2, k=10, random_state=42):
+        data_shuffled = self.user_data.sample(frac=1, random_state=random_state).reset_index(drop=True)
+        test_size = int(len(data_shuffled) * test_ratio)
+        test_set = data_shuffled.iloc[:test_size].copy()
+        train_set = data_shuffled.iloc[test_size:].copy()
+
+        train_avg = train_set.groupby("game_title")["rating"].mean().to_dict()
+        global_avg = train_set["rating"].mean()
+
+        test_set["predicted"] = test_set["game_title"].apply(lambda g: train_avg.get(g, global_avg))
+
+        mse = mean_squared_error(test_set["rating"], test_set["predicted"])
+        rmse = np.sqrt(mse)
+        r2 = r2_score(test_set["rating"], test_set["predicted"])
+
+        user_game_dict = defaultdict(set)
+        for _, row in train_set.iterrows():
+            user_id = row['user_id']
+            game = row['game_title']
+            user_game_dict[user_id].add(game)
+
+        all_games = list(set(self.user_data['game_title']))
+
+        actual_items = []
+        predicted_items = []
+
+        for user_id in user_game_dict.keys():
+            user_test_games = test_set[test_set['user_id'] == user_id]['game_title'].tolist()
+            if not user_test_games:
+                continue
+            user_train_games = list(user_game_dict[user_id])
+            candidate_games = [g for g in all_games if g not in user_train_games]
+            game_scores = [(g, train_avg.get(g, global_avg)) for g in candidate_games]
+            ranked_games = [g for g, _ in sorted(game_scores, key=lambda x: x[1], reverse=True)]
+            actual_items.append(user_test_games)
+            predicted_items.append(ranked_games[:k])
+
+        mapk = self.mean_average_precision_at_k(actual_items, predicted_items, k)
+        ndcg = self.ndcg_at_k(actual_items, predicted_items, k)
+
+        return {
+            'MSE': mse,
+            'RMSE': rmse,
+            'R^2': r2,
+            f'MAP@{k}': mapk,
+            f'NDCG@{k}': ndcg
+        }
+
+def evaluate_naive_model(user_data_path, test_ratio=0.2, k=10):
+    recommender = NaiveGameRecommender(user_data_path)
+    print("Evaluating Naive Model...")
+
+    metrics = recommender.evaluate_metrics(test_ratio=test_ratio, k=k)
+
+    print("\n📊 Naive Model Evaluation Metrics:")
+    print(f"MSE: {metrics['MSE']:.4f}")
+    print(f"RMSE: {metrics['RMSE']:.4f}")
+    print(f"R^2: {metrics['R^2']:.4f}")
+    print(f"MAP@{k}: {metrics[f'MAP@{k}']:.4f}")
+    print(f"NDCG@{k}: {metrics[f'NDCG@{k}']:.4f}")
+
+    return metrics
+
 
 class RecommendationDataset(torch.utils.data.Dataset):
     def __init__(self, ratings_df):
@@ -101,3 +214,31 @@ def evaluate(model, ratings_df, all_game_indices, device='cpu', k=10, num_neg_sa
 
     print(f"Ranking Metrics → MAP@{k}: {mapk:.4f} | NDCG@{k}: {ndcg:.4f}")
     return mse, rmse, r2, mapk, ndcg
+
+
+def main():
+    k = 10
+    test_dataset = "data/inference_data/test_dataset.csv"
+    evaluate_naive_model(test_dataset, test_ratio=0.2, k=k)
+
+    cleaned_games_df = pd.read_csv('data/inference_data/cleaned_games_df.csv')
+    with open('data/inference_data/user_mapping.json') as f:
+        user_mapping = json.load(f)
+    with open('data/inference_data/game_mapping.json') as f:
+        game_mapping = json.load(f)
+
+    # restore model
+    num_users = len(user_mapping)
+    num_games = len(game_mapping)
+
+    test_df = pd.read_csv(test_dataset)
+
+    print('\nEvaluating Deep Learning Model...')
+    model = NCFRecommendationSystem(num_users, num_games)
+    model.load_state_dict(torch.load('models/deep_learning_model_500_combined.pth'))
+    model.to(device)
+
+    evaluate(model, test_df, all_game_indices=list(game_mapping.values()), device=device, k=k)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Updated the README again 
- Added a main() in the evaluate.py. When you run evaluate.py, you can see the eval results for the naive and DL model. Will add the one for the traditional model
- Added a lot of code in evaluate.py, but that's just to get the naive model to work in there for evaluation. Did not change the actual evaluation process or metrics. We are still using MSE, RMSE, R^2, MAP@K, and NCDG@K