### PR TITLE
extended timeout for frontend and commiting mixed loss for dl training

### DIFF
--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -36,7 +36,7 @@ const MainPage = () => {
         ]);
         setLoading(false);
       }
-    }, 5000);
+    }, 30000);
 
     // REMOVED the automatic request for recommendations 
     // as they should have already been sent by HobbiesPage.jsx

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ types-requests>=2.28.0
 cryptography>=40.0.0
 torch==2.6.0
 scikit-learn==1.6.1
+tqdm==4.67.1
+dotenv==0.9.9


### PR DESCRIPTION
- Extended the timeout on the frontend to display fallback recommendations from 5 seconds to 30 seconds
- Updated the requirements.txt to reflect the necessary imports
- Updated the train_model function in the deep learning model to use both BPR and MSE loss functions with a tunable hyperparameter alpha that sets the total loss function to total_loss = alpha*mse_loss + (1-alpha)*bpr_loss